### PR TITLE
Fix security gh check

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -118,16 +118,16 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: ${{ env.GO_VERSION }}
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         queries: +security-and-quality
-
-    - name: Set up Go
-      uses: actions/setup-go@v4
-      with:
-        go-version: ${{ env.GO_VERSION }}
 
     - name: Build project for CodeQL
       run: |

--- a/coverage.out
+++ b/coverage.out
@@ -37,8 +37,8 @@ chronos-kubernetes-scheduler/internal/scheduler/plugin.go:166.2,166.25 1 9
 chronos-kubernetes-scheduler/internal/scheduler/plugin.go:173.136,189.64 6 1314
 chronos-kubernetes-scheduler/internal/scheduler/plugin.go:189.64,198.3 5 626
 chronos-kubernetes-scheduler/internal/scheduler/plugin.go:198.8,198.33 1 688
-chronos-kubernetes-scheduler/internal/scheduler/plugin.go:198.33,207.3 5 654
-chronos-kubernetes-scheduler/internal/scheduler/plugin.go:207.8,214.3 4 34
+chronos-kubernetes-scheduler/internal/scheduler/plugin.go:198.33,207.3 5 651
+chronos-kubernetes-scheduler/internal/scheduler/plugin.go:207.8,214.3 4 37
 chronos-kubernetes-scheduler/internal/scheduler/plugin.go:217.2,219.19 2 1314
 chronos-kubernetes-scheduler/internal/scheduler/plugin.go:226.63,228.2 1 3
 chronos-kubernetes-scheduler/internal/scheduler/plugin.go:232.147,235.35 2 4


### PR DESCRIPTION
This pull request makes a minor change to the workflow configuration and updates the code coverage report. The most notable change is a small reordering in the GitHub Actions workflow for setting up the Go environment.

Workflow configuration update:

* Moved the "Set up Go" step to occur before "Initialize CodeQL" in the `.github/workflows/security.yml` workflow to ensure the Go environment is available for CodeQL analysis.

Coverage report update:

* Updated the `coverage.out` file to reflect recent changes in code execution counts, likely due to minor code changes or test runs.