### PR TITLE
Improve plugin script to show helping intructions on fail to find scheduler decisions

### DIFF
--- a/internal/scheduler/plugin.go
+++ b/internal/scheduler/plugin.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2024.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package scheduler
 
 import (


### PR DESCRIPTION

This pull request improves the user experience and troubleshooting guidance in the `chronos-pod-decision.sh` K9s plugin script. The main changes make the script more robust by avoiding abrupt exits, providing more detailed troubleshooting information, and enhancing user instructions when issues are encountered.

**Error handling and script flow improvements:**

* Changed the script to not exit immediately on errors (`set +e`), and replaced `exit` statements with `return` to allow for proper cleanup and consistent user prompts. The script now always returns 0 to prevent K9s from displaying plugin errors. [[1]](diffhunk://#diff-e5419c0b1ff338c1881005955219fbe1df6caa5c633c39644603ff8210339a83L5-R5) [[2]](diffhunk://#diff-e5419c0b1ff338c1881005955219fbe1df6caa5c633c39644603ff8210339a83R337-R346) [[3]](diffhunk://#diff-e5419c0b1ff338c1881005955219fbe1df6caa5c633c39644603ff8210339a83R359-R384) [[4]](diffhunk://#diff-e5419c0b1ff338c1881005955219fbe1df6caa5c633c39644603ff8210339a83R398-R400)

**Enhanced troubleshooting and user guidance:**

* Added detailed explanations and actionable troubleshooting steps when no scheduling logs are found for a pod, including likely causes and specific `kubectl` commands for investigation.
* Improved feedback and debugging tips when the Chronos scheduler pod cannot be found or when the script is called without a pod name, including context checks and plugin configuration hints. [[1]](diffhunk://#diff-e5419c0b1ff338c1881005955219fbe1df6caa5c633c39644603ff8210339a83R337-R346) [[2]](diffhunk://#diff-e5419c0b1ff338c1881005955219fbe1df6caa5c633c39644603ff8210339a83R359-R384)
* Provided additional troubleshooting tips and manual investigation commands if the pod decision analysis fails, ensuring users have guidance even when automated analysis is unsuccessful.

**Other changes:**

* Removed the license header from `internal/scheduler/plugin.go`