### PR TITLE
Move CHRONOS_SCORE logs to verbosity level 4

### DIFF
--- a/internal/scheduler/plugin.go
+++ b/internal/scheduler/plugin.go
@@ -200,8 +200,7 @@ func (s *Chronos) CalculateOptimizedScore(p *v1.Pod, nodeInfo framework.NodeInfo
 		extensionDuration = newPodDuration
 	}
 
-	// Single consistent log format with essential scheduling details for easy parsing
-	klog.Infof("CHRONOS_SCORE: Pod=%s/%s, Node=%s, Strategy=%s, NewPodDuration=%ds, maxRemainingTime=%ds, ExtensionDuration=%ds, CompletionTime=%s, FinalScore=%d",
+	klog.V(4).Infof("CHRONOS_SCORE: Pod=%s/%s, Node=%s, Strategy=%s, NewPodDuration=%ds, maxRemainingTime=%ds, ExtensionDuration=%ds, CompletionTime=%s, FinalScore=%d",
 		p.Namespace, p.Name, nodeInfo.Node().Name, nodeStrategy, newPodDuration, maxRemainingTime, extensionDuration, completionTime, finalScore)
 	return finalScore
 }


### PR DESCRIPTION
## Summary
- Move `CHRONOS_SCORE` from `klog.Infof` to `klog.V(4).Infof` so default Helm `logging.level: 2` no longer emits one Info line per scored node.
- Continues the hot-path log reduction from 08480221 (which already removed missing-annotation and NormalizeScore Info logs).
- Startup Info and parse warnings are unchanged. Use `-v=4` / `logging.level: 4` when you need CHRONOS_SCORE for k9s or simulation parsing.

## Test plan
- [x] Diff reviewed: only Score logging level changed
- [ ] `make test-unit` (optional local)
- [ ] With default `logging.level: 2`, confirm Score cycles do not emit `CHRONOS_SCORE`
- [ ] With `logging.level: 4`, confirm `CHRONOS_SCORE` still appears for debugging


Made with [Cursor](https://cursor.com)